### PR TITLE
Update to oresat-configs v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ pip install -r zephyr/scripts/requirements.txt
 ### Install OreSat Configs
 
 ```bash
-pip install oresat-configs>=1.0.0
+pip install --user oresat-configs~=1.0.0
 ```
 
 ### Test compile and flash

--- a/README.md
+++ b/README.md
@@ -78,14 +78,8 @@ pip install -r zephyr/scripts/requirements.txt
 
 ### Install OreSat Configs
 
-While the latest oresat-configs release can be install via `pip`,
-for development, it is better to have latest code from the git repo.
-
 ```bash
-cd oresat-configs
-pip install -r requirements.txt
-./build_and_install.sh
-cd -
+pip install oresat-configs>=1.0.0
 ```
 
 ### Test compile and flash

--- a/apps/adcs/CMakeLists.txt
+++ b/apps/adcs/CMakeLists.txt
@@ -2,10 +2,9 @@ cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
-set(CARD "adcs")
-project("oresat-${CARD}" LANGUAGES C)
+project("oresat-adcs" LANGUAGES C)
 
-execute_process(COMMAND bash -c "oresat-configs fw-files ${CARD} -d gen")
+execute_process(COMMAND bash -c "oresat-configs canopennode od.yaml ../../common/od.yaml -d gen")
 
 target_sources(app PRIVATE
   src/main.c

--- a/apps/adcs/od.yaml
+++ b/apps/adcs/od.yaml
@@ -1,0 +1,381 @@
+name: adcs
+nice_name: ADCS
+
+objects:
+  - index: 0x4000
+    name: gyroscope
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: pitch_rate
+        data_type: int16
+        description: x-axis rate
+        access_type: ro
+        unit: deg/s
+
+      - subindex: 0x2
+        name: yaw_rate
+        data_type: int16
+        description: y-axis rate
+        access_type: ro
+        unit: deg/s
+
+      - subindex: 0x3
+        name: roll_rate
+        data_type: int16
+        description: z-axis rate
+        access_type: ro
+        unit: deg/s
+
+      - subindex: 0x4
+        name: pitch_rate_raw
+        data_type: uint16
+        description: raw x-axis rate
+        access_type: ro
+
+      - subindex: 0x5
+        name: yaw_rate_raw
+        data_type: uint16
+        description: raw y-axis rate
+        access_type: ro
+
+      - subindex: 0x6
+        name: roll_rate_raw
+        data_type: uint16
+        description: raw z-axis rate
+        access_type: ro
+
+  - index: 0x4001
+    name: accelerometer
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: x
+        data_type: int16
+        description: x acceleration
+        access_type: ro
+        unit: g
+        scale_factor: 0.001
+
+      - subindex: 0x2
+        name: y
+        data_type: int16
+        description: y acceleration
+        access_type: ro
+        unit: g
+        scale_factor: 0.001
+
+      - subindex: 0x3
+        name: z
+        data_type: int16
+        description: z acceleration
+        unit: g
+        access_type: ro
+        scale_factor: 0.001
+
+      - subindex: 0x4
+        name: x_raw
+        data_type: uint16
+        description: raw x acceleration value
+        access_type: ro
+
+      - subindex: 0x5
+        name: y_raw
+        data_type: uint16
+        description: raw y acceleration value
+        access_type: ro
+
+      - subindex: 0x6
+        name: z_raw
+        data_type: uint16
+        description: raw z acceleration value
+        access_type: ro
+
+  - index: 0x4002
+    name: temperature
+    data_type: int8
+    description: imu sensor temperature
+    access_type: ro
+    unit: C
+
+  - index: 0x4003
+    name: pos_z_magnetometer_1
+    object_type: record
+    description: +z endcard magnetometer 1 data
+    subindexes:
+      - subindex: 0x1
+        name: x
+        data_type: int16
+        description: +z mag 1 x-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+      - subindex: 0x2
+        name: y
+        data_type: int16
+        description: +z mag 1 y-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+      - subindex: 0x3
+        name: z
+        data_type: int16
+        description: +z mag 1 z-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+  - index: 0x4004
+    name: pos_z_magnetometer_2
+    object_type: record
+    description: +z endcard magnetometer 2 data
+    subindexes:
+      - subindex: 0x1
+        name: x
+        data_type: int16
+        description: +z mag 2 x-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+      - subindex: 0x2
+        name: y
+        data_type: int16
+        description: +z mag 2 y-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+      - subindex: 0x3
+        name: z
+        data_type: int16
+        description: +z mag 2 z-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+  - index: 0x4005
+    name: min_z_magnetometer_1
+    object_type: record
+    description: -z endcard magnetometer 1 data
+    subindexes:
+      - subindex: 0x1
+        name: x
+        data_type: int16
+        description: -z mag 1 x-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+      - subindex: 0x2
+        name: y
+        data_type: int16
+        description: -z mag 1 y-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+      - subindex: 0x3
+        name: z
+        data_type: int16
+        description: -z mag 1 z-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+  - index: 0x4006
+    name: min_z_magnetometer_2
+    object_type: record
+    description: -z endcard magnetometer 2 data
+    subindexes:
+      - subindex: 0x1
+        name: x
+        data_type: int16
+        description: -z mag 2 x-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+      - subindex: 0x2
+        name: y
+        data_type: int16
+        description: -z mag 2 y-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+      - subindex: 0x3
+        name: z
+        data_type: int16
+        description: -z mag 2 z-axis magnetic field
+        access_type: ro
+        low_limit: -8192
+        high_limit: 8192
+        unit: gauss
+        scale_factor: 0.001
+
+  - index: 0x4007
+    name: magnetorquer
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: current_x
+        data_type: int32
+        description: current feedback in the x-axis
+        access_type: ro
+        unit: uA
+
+      - subindex: 0x2
+        name: current_y
+        data_type: int32
+        description: current feedback in the y-axis
+        access_type: ro
+        unit: uA
+
+      - subindex: 0x3
+        name: current_z
+        data_type: int32
+        description: current feedback in the y-axis
+        access_type: ro
+        unit: uA
+
+      - subindex: 0x4
+        name: current_x_setpoint
+        data_type: int32
+        description: Setpoint for current in thex x-axis
+        access_type: rw
+        unit: uA
+
+      - subindex: 0x5
+        name: current_y_setpoint
+        data_type: int32
+        description: Setpoint for current in the y-axis
+        access_type: rw
+        unit: uA
+
+      - subindex: 0x6
+        name: current_z_setpoint
+        data_type: int32
+        description: Setpoint for current in thex z-axis
+        access_type: rw
+        unit: uA
+
+      - subindex: 0x7
+        name: pwm_x
+        data_type: int16
+        description: X axis
+        access_type: ro
+        low_limit: 0
+        high_limit: 10000
+        scale_factor: 0.01
+        unit: "%"
+
+      - subindex: 0x8
+        name: pwm_y
+        data_type: int16
+        description: X axis
+        access_type: ro
+        low_limit: 0
+        high_limit: 10000
+        scale_factor: 0.01
+        unit: "%"
+
+      - subindex: 0x9
+        name: pwm_z
+        data_type: int16
+        description: X axis
+        access_type: ro
+        low_limit: 0
+        high_limit: 10000
+        scale_factor: 0.01
+        unit: "%"
+
+tpdos:
+  - num: 1
+    fields:
+      - [gyroscope, pitch_rate]
+      - [gyroscope, yaw_rate]
+      - [gyroscope, roll_rate]
+    event_timer_ms: 1000
+
+  - num: 2
+    fields:
+      - [accelerometer, x]
+      - [accelerometer, y]
+      - [accelerometer, z]
+    event_timer_ms: 1000
+
+  - num: 3
+    fields:
+      - [temperature]
+    event_timer_ms: 1000
+
+  - num: 4
+    fields:
+      - [pos_z_magnetometer_1, x]
+      - [pos_z_magnetometer_1, y]
+      - [pos_z_magnetometer_1, z]
+    event_timer_ms: 1000
+
+  - num: 5
+    fields:
+      - [pos_z_magnetometer_2, x]
+      - [pos_z_magnetometer_2, y]
+      - [pos_z_magnetometer_2, z]
+    event_timer_ms: 1000
+
+  - num: 6
+    fields:
+      - [min_z_magnetometer_1, x]
+      - [min_z_magnetometer_1, y]
+      - [min_z_magnetometer_1, z]
+    event_timer_ms: 1000
+
+  - num: 7
+    fields:
+      - [min_z_magnetometer_2, x]
+      - [min_z_magnetometer_2, y]
+      - [min_z_magnetometer_2, z]
+    event_timer_ms: 1000
+
+  - num: 8
+    fields:
+      - [magnetorquer, current_x]
+      - [magnetorquer, pwm_x]
+    event_timer_ms: 1000
+
+  - num: 9
+    fields:
+      - [magnetorquer, current_y]
+      - [magnetorquer, pwm_y]
+    event_timer_ms: 1000
+
+  - num: 10
+    fields:
+      - [magnetorquer, current_z]
+      - [magnetorquer, pwm_z]
+    event_timer_ms: 1000

--- a/apps/battery/CMakeLists.txt
+++ b/apps/battery/CMakeLists.txt
@@ -2,10 +2,9 @@ cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
-set(CARD "battery")
-project("oresat-${CARD}" LANGUAGES C)
+project("oresat-battery" LANGUAGES C)
 
-execute_process(COMMAND bash -c "oresat-configs fw-files ${CARD} -d gen")
+execute_process(COMMAND bash -c "oresat-configs canopennode od.yaml ../../common/od.yaml -d gen")
 
 target_sources(app PRIVATE
   src/main.c

--- a/apps/battery/od.yaml
+++ b/apps/battery/od.yaml
@@ -1,0 +1,410 @@
+name: battery
+nice_name: Battery
+
+objects:
+  - index: 0x4000
+    name: pack_1
+    description: battery pack 1 telemetry
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: vbatt
+        data_type: uint16
+        description: pack voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x2
+        name: vcell_max
+        data_type: uint16
+        description: max voltage for a cell
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x3
+        name: vcell_min
+        data_type: uint16
+        description: min voltage for a cell
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x4
+        name: vcell
+        data_type: uint16
+        description: lowest cell voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x5
+        name: vcell_1
+        data_type: uint16
+        description: cell 1 voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x6
+        name: vcell_2
+        data_type: uint16
+        description: cell 2 voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x7
+        name: vcell_avg
+        data_type: uint16
+        description: average voltage of both cells
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x8
+        name: current
+        data_type: int16
+        description: pack current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0x9
+        name: current_avg
+        data_type: int16
+        description: pack average current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0xa
+        name: current_max
+        data_type: int16
+        description: pack max current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0xb
+        name: current_min
+        data_type: int16
+        description: pack min current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0xc
+        name: full_capacity
+        data_type: uint16
+        description: capacity of battery pack
+        access_type: ro
+        unit: mAh
+
+      - subindex: 0xd
+        name: reported_capacity
+        data_type: uint16
+        description: reported capacity of battery pack
+        access_type: ro
+        unit: mAh
+
+      - subindex: 0xe
+        name: time_to_empty
+        data_type: uint16
+        description: estimate of time until battery pack is empty
+        access_type: ro
+        unit: s
+
+      - subindex: 0xf
+        name: time_to_full
+        data_type: uint16
+        description: estimate of time until battery pack is full
+        access_type: ro
+        unit: s
+
+      - subindex: 0x10
+        name: cycles
+        data_type: uint16
+        description: charge/discharge cycles
+        access_type: ro
+        high_limit: 10485
+
+      - subindex: 0x11
+        name: reported_state_of_charge
+        data_type: uint8
+        description: reported charge percent
+        access_type: ro
+        high_limit: 100
+        unit: "%"
+
+      - subindex: 0x12
+        name: temperature
+        data_type: int8
+        description: temperature of battery pack
+        access_type: ro
+        unit: C
+
+      - subindex: 0x13
+        name: temperature_avg
+        data_type: int8
+        description: average temperature of battery pack
+        access_type: ro
+        unit: C
+
+      - subindex: 0x14
+        name: temperature_max
+        data_type: int8
+        description: max temperature of battery pack
+        access_type: ro
+        unit: C
+
+      - subindex: 0x15
+        name: temperature_min
+        data_type: int8
+        description: min temperature of battery pack
+        access_type: ro
+        unit: C
+
+      - subindex: 0x16
+        name: status
+        data_type: uint8
+        bit_definitions:
+          HEATER_ON: 0
+          DISCHARGE_DISABLE: 1
+          CHARGE_DISABLE: 2
+          DISCHARGE_STATUS: 3
+          CHARGE_STATUS: 4
+        access_type: ro
+
+  - index: 0x4001
+    name: pack_2
+    description: battery pack 2 telemetry
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: vbatt
+        data_type: uint16
+        description: pack voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x2
+        name: vcell_max
+        data_type: uint16
+        description: max voltage for a cell
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x3
+        name: vcell_min
+        data_type: uint16
+        description: min voltage for a cell
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x4
+        name: vcell
+        data_type: uint16
+        description: lowest cell voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x5
+        name: vcell_1
+        data_type: uint16
+        description: cell 1 voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x6
+        name: vcell_2
+        data_type: uint16
+        description: cell 2 voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x7
+        name: vcell_avg
+        data_type: uint16
+        description: average voltage of both cells
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x8
+        name: current
+        data_type: int16
+        description: pack current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0x9
+        name: current_avg
+        data_type: int16
+        description: pack average current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0xa
+        name: current_max
+        data_type: int16
+        description: pack max current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0xb
+        name: current_min
+        data_type: int16
+        description: pack min current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0xc
+        name: full_capacity
+        data_type: uint16
+        description: capacity of battery pack
+        access_type: ro
+        unit: mAh
+
+      - subindex: 0xd
+        name: reported_capacity
+        data_type: uint16
+        description: reported capacity of battery pack
+        access_type: ro
+        unit: mAh
+
+      - subindex: 0xe
+        name: time_to_empty
+        data_type: uint16
+        description: estimate of time until battery pack is empty
+        access_type: ro
+        unit: s
+
+      - subindex: 0xf
+        name: time_to_full
+        data_type: uint16
+        description: estimate of time until battery pack is full
+        access_type: ro
+        unit: s
+
+      - subindex: 0x10
+        name: cycles
+        data_type: uint16
+        description: charge/discharge cycles
+        access_type: ro
+        high_limit: 10485
+
+      - subindex: 0x11
+        name: reported_state_of_charge
+        data_type: uint8
+        description: reported charge percent
+        access_type: ro
+        high_limit: 100
+        unit: "%"
+
+      - subindex: 0x12
+        name: temperature
+        data_type: int8
+        description: temperature of battery pack
+        access_type: ro
+        unit: C
+
+      - subindex: 0x13
+        name: temperature_avg
+        data_type: int8
+        description: average temperature of battery pack
+        access_type: ro
+        unit: C
+
+      - subindex: 0x14
+        name: temperature_max
+        data_type: int8
+        description: max temperature of battery pack
+        access_type: ro
+        unit: C
+
+      - subindex: 0x15
+        name: temperature_min
+        data_type: int8
+        description: min temperature of battery pack
+        access_type: ro
+        unit: C
+
+      - subindex: 0x16
+        name: status
+        data_type: uint8
+        bit_definitions:
+          HEATER_ON: 0
+          DISCHARGE_DISABLE: 1
+          CHARGE_DISABLE: 2
+          DISCHARGE_STATUS: 3
+          CHARGE_STATUS: 4
+        access_type: ro
+
+tpdos:
+  - num: 1
+    fields:
+      - [pack_1, vbatt]
+      - [pack_1, vcell_max]
+      - [pack_1, vcell_min]
+      - [pack_1, vcell]
+    event_timer_ms: 10000
+
+  - num: 2
+    fields:
+      - [pack_1, vcell_1]
+      - [pack_1, vcell_2]
+      - [pack_1, vcell_avg]
+    event_timer_ms: 10000
+
+  - num: 3
+    fields:
+      - [pack_1, current]
+      - [pack_1, current_avg]
+      - [pack_1, current_max]
+      - [pack_1, current_min]
+    event_timer_ms: 10000
+
+  - num: 4
+    fields:
+      - [pack_1, temperature]
+      - [pack_1, temperature_avg]
+      - [pack_1, temperature_max]
+      - [pack_1, temperature_min]
+    event_timer_ms: 10000
+
+  - num: 5
+    fields:
+      - [pack_1, full_capacity]
+      - [pack_1, reported_capacity]
+      - [pack_1, reported_state_of_charge]
+      - [pack_1, status]
+    event_timer_ms: 10000
+
+  - num: 6
+    fields:
+      - [pack_2, vbatt]
+      - [pack_2, vcell_max]
+      - [pack_2, vcell_min]
+      - [pack_2, vcell]
+    event_timer_ms: 10000
+
+  - num: 7
+    fields:
+      - [pack_2, vcell_1]
+      - [pack_2, vcell_2]
+      - [pack_2, vcell_avg]
+    event_timer_ms: 10000
+
+  - num: 8
+    fields:
+      - [pack_2, current]
+      - [pack_2, current_avg]
+      - [pack_2, current_max]
+      - [pack_2, current_min]
+    event_timer_ms: 10000
+
+  - num: 9
+    fields:
+      - [pack_2, temperature]
+      - [pack_2, temperature_avg]
+      - [pack_2, temperature_max]
+      - [pack_2, temperature_min]
+    event_timer_ms: 10000
+
+  - num: 10
+    fields:
+      - [pack_2, full_capacity]
+      - [pack_2, reported_capacity]
+      - [pack_2, reported_state_of_charge]
+      - [pack_2, status]
+    event_timer_ms: 10000

--- a/apps/diode_test/CMakeLists.txt
+++ b/apps/diode_test/CMakeLists.txt
@@ -2,10 +2,9 @@ cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
-set(CARD "diode_test")
-project("oresat-${CARD}" LANGUAGES C)
+project("oresat-diode-test" LANGUAGES C)
 
-execute_process(COMMAND bash -c "oresat-configs fw-files ${CARD} -d gen")
+execute_process(COMMAND bash -c "oresat-configs canopennode od.yaml ../../common/od.yaml -d gen")
 
 target_sources(app PRIVATE
   src/main.c

--- a/apps/diode_test/od.yaml
+++ b/apps/diode_test/od.yaml
@@ -1,0 +1,114 @@
+name: diode_test
+nice_name: Diode Test
+
+objects:
+  - index: 0x4000
+    name: dtc
+    description: diode test card
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: ctrl
+        data_type: uint8
+        default: 0x0
+        description: enumeration of control functions
+        value_descriptions:
+          NOP: 0
+          dtc_dacStart: 1
+          dtc_dacStop: 2
+          dtc_gptStart: 3
+          dtc_gptStop: 4
+          dtc_adcStart: 5
+          dtc_adcStop: 6
+          dtc_muxEnable: 7
+          dtc_muxDisable: 8
+          dtc_clearErrors: 9
+        access_type: rw
+
+      - subindex: 0x2
+        name: mux_select
+        data_type: uint8
+        high_limit: 0x07
+        low_limit: 0x0
+        default: 0x0
+        description: diode mux select
+        access_type: rw
+
+      - subindex: 0x3
+        name: dac
+        data_type: uint16
+        high_limit: 0xFFF
+        low_limit: 0x0
+        default: 0x0
+        description: dac output
+        access_type: rw
+
+      - subindex: 0x4
+        name: status
+        data_type: uint16
+        default: 0x0
+        description: status bits
+        access_type: rw
+        bit_definitions:
+          DAC_EN: 0
+          GPT_EN: 1
+          ADC_EN: 2
+          MUX_EN: 3
+          MUX_A0: 4
+          MUX_A1: 5
+          MUX_A2: 6
+
+      - subindex: 0x5
+        name: error
+        data_type: uint16
+        default: 0x0
+        description: error bits
+        access_type: rw
+        bit_definitions:
+          DAC: 0
+          ADC_CB: 1
+          ADC_START: 2
+          ADC_STOP: 3
+
+  - index: 0x4001
+    name: adcsample
+    description: adc samples
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: led_current
+        data_type: uint16
+        description: led feedback current
+        access_type: rw
+        unit: lsb
+
+      - subindex: 0x2
+        name: led_swir_pd_current
+        data_type: uint16
+        description: swir feedback current
+        access_type: rw
+        unit: lsb
+
+      - subindex: 0x3
+        name: uv_pd_current
+        data_type: uint16
+        description: uv feedback current
+        access_type: rw
+        unit: lsb
+
+tpdos:
+  - num: 1
+    fields:
+      - [dtc, ctrl]
+      - [dtc, mux_select]
+      - [dtc, dac]
+      - [dtc, status]
+      - [dtc, error]
+    event_timer_ms: 10000
+
+  - num: 2
+    fields:
+      - [adcsample, led_current]
+      - [adcsample, led_swir_pd_current]
+      - [adcsample, uv_pd_current]
+    event_timer_ms: 10000

--- a/apps/reaction_wheel/CMakeLists.txt
+++ b/apps/reaction_wheel/CMakeLists.txt
@@ -2,10 +2,9 @@ cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
-set(CARD "rw")
-project("oresat-${CARD}" LANGUAGES C)
+project("oresat-reaction-wheel" LANGUAGES C)
 
-execute_process(COMMAND bash -c "oresat-configs fw-files ${CARD} -d gen")
+execute_process(COMMAND bash -c "oresat-configs canopennode od.yaml ../../common/od.yaml -d gen")
 
 target_sources(app PRIVATE
   src/main.c

--- a/apps/reaction_wheel/od.yaml
+++ b/apps/reaction_wheel/od.yaml
@@ -1,0 +1,200 @@
+name: reaction_wheel
+nice_name: Reaction Wheel
+
+objects:
+  - index: 0x4000
+    name: ctrl_stat
+    description: reaction wheel controller status
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: current_state
+        data_type: uint8
+        description: controller state
+        access_type: ro
+        value_descriptions:
+          none: 0
+          idle: 1
+          system_error: 2
+          controller_error: 3
+          torque_control: 4
+          vel_control: 5
+          pos_control: 6
+          motor_resistance_cal: 7
+          motor_inductance_cal: 8
+          encoder_dir_cal: 9
+          encoder_offset_cal: 10
+          encoder_test: 11
+          open_loop_control: 12
+          clear_errors: 13
+          encoder_validation: 14
+          shitty_offset_cal: 15
+          vel_ramp_control: 16
+
+      - subindex: 0x2
+        name: procedure_result
+        data_type: uint8
+        description: last state return code
+        access_type: ro
+
+      - subindex: 0x3
+        name: errors
+        data_type: uint32
+        description: system error bitmask
+        access_type: ro
+        bit_definitions:
+          inverter_calibration_invalid: 0
+          phase_currents_invalid: 1
+          phase_currents_measurement_missing: 2
+          pwm_timing_invalid: 3
+          pwm_timing_update_missing: 4
+          vbus_overvoltage: 5
+          vbus_undervoltage: 6
+          ibus_overcurrent: 7
+          motor_overcurrent: 8
+          motor_phase_leakage: 9
+          motor_resistance_out_of_range: 10
+          motor_inductance_out_of_range: 11
+          encoder_reading_missing: 12
+          encoder_estimate_missing: 13
+          encoder_reading_invalid: 14
+          encoder_failure: 15
+          phase_current_usage_missing: 16
+          pwm_timing_usage_missing: 17
+          phase_current_leakage: 18
+          encoder_reading_usage_missing: 19
+          motor_unbalanced_phases: 20
+          modulation: 21
+
+  - index: 0x4001
+    name: motor
+    description: reaction wheel motor vel/current
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: velocity
+        data_type: float32
+        description: motor velocity
+        access_type: ro
+        unit: rev/s
+
+      - subindex: 0x2
+        name: current
+        data_type: float32
+        description: motor current
+        access_type: ro
+        unit: A
+
+  - index: 0x4002
+    name: bus
+    description: reaction wheel DC bus voltage/current
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: voltage
+        data_type: float32
+        description: bus voltage
+        access_type: ro
+        unit: V
+
+      - subindex: 0x2
+        name: current
+        data_type: float32
+        description: bus current
+        access_type: ro
+        unit: A
+
+  - index: 0x4003
+    name: temperature
+    description: reaction wheel controller temperatures
+    object_type: array
+    generate_subindexes:
+      subindexes: 3
+      name: sensor
+      data_type: int16
+      access_type: ro
+      unit: C
+      scale_factor: 0.01
+
+  - index: 0x4004
+    name: requested
+    description: reaction wheel requested state
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: state
+        data_type: uint8
+        description: requested state
+        access_type: rw
+
+  - index: 0x4005
+    name: signals
+    description: reaction wheel setpoints
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: setpoint
+        data_type: float32
+        description: setpoint 1
+        access_type: rw
+
+      - subindex: 0x2
+        name: reserved_feedforward
+        data_type: float32
+        description: setpoint 2 (e.g. feedforward)
+        access_type: rw
+
+  - index: 0x4006
+    name: reserved
+    description: reaction wheel config params - reserved
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: subindex_1
+        data_type: float32
+        description: reserved 1
+        access_type: rw
+
+      - subindex: 0x2
+        name: subindex_2
+        data_type: float32
+        description: reserved 2
+        access_type: rw
+
+  - index: 0x4007
+    name: reboot
+    description: reaction wheel reboot request
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: request
+        data_type: uint8
+        description: write 1 to reboot
+        access_type: rw
+
+tpdos:
+  - num: 1
+    fields:
+      - [ctrl_stat, current_state]
+      - [ctrl_stat, procedure_result]
+      - [ctrl_stat, errors]
+    event_timer_ms: 5000
+
+  - num: 2
+    fields:
+      - [motor, velocity]
+      - [motor, current]
+    event_timer_ms: 5000
+
+  - num: 3
+    fields:
+      - [bus, voltage]
+      - [bus, current]
+    event_timer_ms: 5000
+
+  - num: 4
+    fields:
+      - [temperature, sensor_1]
+      - [temperature, sensor_2]
+      - [temperature, sensor_3]
+    event_timer_ms: 5000

--- a/apps/solar/CMakeLists.txt
+++ b/apps/solar/CMakeLists.txt
@@ -2,10 +2,9 @@ cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
-set(CARD "solar")
-project("oresat-${CARD}" LANGUAGES C)
+project("oresat-solar" LANGUAGES C)
 
-execute_process(COMMAND bash -c "oresat-configs fw-files ${CARD} -d gen")
+execute_process(COMMAND bash -c "oresat-configs canopennode od.yaml ../../common/od.yaml -d gen")
 
 target_sources(app PRIVATE
   src/main.c

--- a/apps/solar/od.yaml
+++ b/apps/solar/od.yaml
@@ -1,0 +1,176 @@
+name: solar
+nice_name: Solar
+
+objects:
+  - index: 0x4000
+    name: output
+    description: solar module output
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: voltage
+        data_type: uint16
+        description: voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x2
+        name: current
+        data_type: int16
+        description: current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0x3
+        name: power
+        data_type: uint16
+        description: power
+        access_type: ro
+        unit: mW
+
+      - subindex: 0x4
+        name: voltage_avg
+        data_type: uint16
+        description: average voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x5
+        name: current_avg
+        data_type: int16
+        description: average current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0x6
+        name: power_avg
+        data_type: uint16
+        description: average power
+        access_type: ro
+        unit: mW
+
+      - subindex: 0x7
+        name: voltage_max
+        data_type: uint16
+        description: max voltage
+        access_type: ro
+        unit: mV
+
+      - subindex: 0x8
+        name: current_max
+        data_type: int16
+        description: max current
+        access_type: ro
+        unit: mA
+
+      - subindex: 0x9
+        name: power_max
+        data_type: uint16
+        description: max power
+        access_type: ro
+        unit: mW
+
+      - subindex: 0xa
+        name: energy
+        data_type: uint16
+        description: storing energy
+        access_type: ro
+        unit: mJ
+
+  - index: 0x4001
+    name: cell_1
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: temperature
+        data_type: int8
+        description: cell 1 temperature
+        access_type: ro
+        unit: C
+
+      - subindex: 0x2
+        name: temperature_min
+        data_type: int8
+        description: min cell 1 temperature
+        access_type: ro
+        unit: C
+
+      - subindex: 0x3
+        name: temperature_max
+        data_type: int8
+        description: max cell 1 temperature
+        access_type: ro
+        unit: C
+
+  - index: 0x4002
+    name: cell_2
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: temperature
+        data_type: int8
+        description: cell 2 temperature
+        access_type: ro
+        unit: C
+
+      - subindex: 0x2
+        name: temperature_min
+        data_type: int8
+        description: min cell 2 temperature
+        access_type: ro
+        unit: C
+
+      - subindex: 0x3
+        name: temperature_max
+        data_type: int8
+        description: max cell 2 temperature
+        access_type: ro
+        unit: C
+
+  - index: 0x4003
+    name: mppt_alg
+    data_type: uint8
+    description: mppt (maximum power point tracking) algorithm
+    value_descriptions:
+      perturb_and_observe: 0
+    access_type: rw
+
+  - index: 0x4004
+    name: lt1618_iadj
+    data_type: uint16
+    description: i_adj pin voltage
+    access_type: ro
+    unit: mV
+
+tpdos:
+  - num: 1
+    fields:
+      - [output, voltage]
+      - [output, current]
+      - [output, power]
+      - [output, voltage_avg]
+    event_timer_ms: 10000
+
+  - num: 2
+    fields:
+      - [output, current_avg]
+      - [output, power_avg]
+      - [output, voltage_max]
+      - [output, current_max]
+    event_timer_ms: 10000
+
+  - num: 3
+    fields:
+      - [output, power_max]
+      - [output, energy]
+    event_timer_ms: 10000
+
+  - num: 4
+    fields:
+      - [cell_1, temperature]
+      - [cell_2, temperature]
+      - [cell_1, temperature_min]
+      - [cell_2, temperature_min]
+      - [cell_1, temperature_max]
+      - [cell_2, temperature_max]
+    event_timer_ms: 10000

--- a/common/od.yaml
+++ b/common/od.yaml
@@ -1,0 +1,116 @@
+name: firmware
+nice_name: Firmware
+
+std_objects:
+  - device_type
+  - error_register
+  - predefined_error_field
+  - cob_id_sync
+  - communication_cycle_period
+  - cob_id_emergency_message
+  - inhibit_time_emcy
+  - producer_heartbeat_time
+  - identity
+  - synchronous_counter_overflow_value
+  - sdo_server_parameter
+  - scet
+  - utc
+
+objects:
+  - index: 0x3000
+    name: satellite_id
+    data_type: uint8
+    description: the unique oresat satellite id
+    access_type: const
+
+  - index: 0x3001
+    name: flight_mode
+    data_type: bool
+    description: card is in flight mode
+    access_type: ro
+    default: true
+
+  - index: 0x3002
+    name: versions
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: hw_version
+        data_type: str
+        description: card hw version
+        access_type: const
+        default: "0.0"
+
+      - subindex: 0x2
+        name: configs_version
+        data_type: str
+        description: oresat configs version
+        access_type: const
+        default: "0.0.0"
+
+      # subindex 0x3 reserved
+
+      - subindex: 0x4
+        name: fw_version
+        data_type: str
+        description: app fw version
+        access_type: const
+        default: "0.0.0"
+
+  - index: 0x3003
+    name: system
+    object_type: record
+    subindexes:
+      - subindex: 0x1
+        name: reset
+        data_type: uint8
+        description: reset the app
+        value_descriptions:
+          no_stop: 0
+          soft_reset: 1
+          hard_reset: 2
+          factory_reset: 3
+          poweroff: 4
+        access_type: wo
+
+      # subindex 0x2 reserved for storage_percent
+      # subindex 0x3 reserved for ram_percent
+      # subindex 0x4 reserved for unix_time
+
+      - subindex: 0x5
+        name: uptime
+        data_type: uint32
+        description: uptime
+        access_type: ro
+        unit: s
+
+      # subindex 0x6 reserved for power_cycles
+
+      - subindex: 0x7
+        name: temperature
+        data_type: int8
+        description: processor temperature
+        access_type: ro
+        unit: C
+
+      - subindex: 0x8
+        name: vrefint
+        description: processor internal voltage reference
+        data_type: uint16
+        access_type: ro
+        scale_factor: 0.001
+        unit: V
+
+        # subindex 0x9 reserved for boot_select
+
+  # index 0x3004 reserved
+  # index 0x3005 reserved
+  # index 0x3006 reserved
+  # index 0x3007 reserved
+  # index 0x3008 reserved
+
+  - index: 0x3009
+    name: board_id
+    data_type: uint8
+    description: the unique board id for the board revision
+    access_type: const

--- a/common/oresat.h
+++ b/common/oresat.h
@@ -24,32 +24,30 @@ static inline uint8_t oresat_get_node_id(void)
 
 static inline void oresat_fix_pdo_cob_ids(uint8_t node_id)
 {
+	int i;
 	uint32_t cob_id;
 	OD_entry_t *entry;
+	for (int e = 0; e < OD->size; e++) {
+		entry = &OD->list[e];
 #if OD_CNT_RPDO > 0
-	for (int i = 0; i < OD_CNT_RPDO; i++) {
-		entry = OD_find(OD, 0x1400 + i);
-		if (!entry) {
-			continue;
+		if ((entry->index >= 0x1400) && (entry->index < 0x1600)) {
+			i = entry->index - 0x1400;
+			OD_get_u32(entry, 1, &cob_id, true);
+			if ((cob_id & 0x7FF) == (0x200U + (0x100U * (i % 4) + (i / 4)))) {
+				OD_set_u32(entry, 1, cob_id + node_id, true);
+			}
 		}
-		OD_get_u32(entry, 1, &cob_id, true);
-		if (cob_id == 0x200U + (0x100U * (i % 4))) {
-			OD_set_u32(entry, 1, cob_id + node_id + (i / 4), true);
-		}
-	}
 #endif
 #if OD_CNT_TPDO > 0
-	for (int i = 0; i < OD_CNT_TPDO; i++) {
-		entry = OD_find(OD, 0x1800 + i);
-		if (!entry) {
-			continue;
+		if ((entry->index >= 0x1800) && (entry->index < 0x1A00)) {
+			i = entry->index - 0x1800;
+			OD_get_u32(entry, 1, &cob_id, true);
+			if ((cob_id & 0x7FF) == (0x180U + (0x100U * (i % 4) + (i / 4)))) {
+				OD_set_u32(entry, 1, cob_id + node_id, true);
+			}
 		}
-		OD_get_u32(entry, 1, &cob_id, true);
-		if (cob_id == 0x180U + (0x100U * (i % 4))) {
-			OD_set_u32(entry, 1, cob_id + node_id + (i / 4), true);
-		}
-	}
 #endif
+	}
 }
 
 #endif

--- a/format_code.sh
+++ b/format_code.sh
@@ -3,4 +3,4 @@
 # a .clang-format-ignore file will only be used by clang-format v18.0.1 or newer.
 #
 # This method supports older clang-format versions.
-find . -name "*.[h/c]" -not -path "./common/canopennode_v4/CANopenNode/*" | xargs clang-format -i
+find . -wholename "*.[h/c]" -not -path "./common/canopennode_v4/CANopenNode/*" -not -path "./apps/*/build/*" -not -path "./apps/*gen/*" | xargs clang-format -i $@

--- a/west.yml
+++ b/west.yml
@@ -14,5 +14,3 @@ manifest:
       url: https://github.com/CANopenNode/CANopenNode
       revision: 58012aa
       path: oresat-zephyr/common/canopennode_v4/CANopenNode
-    - name: oresat-configs
-      url: https://github.com/oresat/oresat-configs


### PR DESCRIPTION
Moved the `od.yaml` configs for each card and the common firmware `od.yaml` that used to live `oresat-configs`.

Reworked the PDO COB-ID fix to work with `oresat-configs` v1.

Removed `oresat-configs` from west configs

Fixed the `format_code.sh` script